### PR TITLE
Refactor DockerHub samples to use multi-arch tags

### DIFF
--- a/README.DockerHub.md
+++ b/README.DockerHub.md
@@ -1,0 +1,96 @@
+# Supported Windows amd64 tags
+
+- [`dotnetapp-nanoserver`, `dotnetapp`, `latest` (*dotnetapp-prod/Dockerfile*)](https://github.com/dotnet/dotnet-docker-samples/blob/master/dotnetapp-prod/Dockerfile)
+
+# Supported Linux amd64 tags
+
+- [`dotnetapp-stretch`, `dotnetapp`, `latest` (*dotnetapp-prod/Dockerfile*)](https://github.com/dotnet/dotnet-docker-samples/blob/master/dotnetapp-prod/Dockerfile)
+
+# Supported Linux arm32 tags
+
+- [`dotnetapp-stretch-arm32v7`, `dotnetapp`, `latest` (*dotnetapp-prod/Dockerfile.arm32*)](https://github.com/dotnet/dotnet-docker-samples/blob/master/dotnetapp-prod/Dockerfile.arm32)
+
+For more information about these images and their history, please see [the relevant Dockerfile (`dotnet/dotnet-docker-samples`)](https://github.com/dotnet/dotnet-docker-samples/search?utf8=%E2%9C%93&q=FROM&type=Code). These images are updated via [pull requests to the `dotnet/dotnet-docker-samples` GitHub repo](https://github.com/dotnet/dotnet-docker-samples/pulls?utf8=%E2%9C%93&q=).
+
+# .NET Core Docker Samples
+
+This repo contains samples (one so far) that demonstrate various .NET Core Docker configurations.
+
+You can see the source for these samples at [dotnet/dotnet-docker-samples](https://github.com/dotnet/dotnet-docker-samples/tree/master) on GitHub.
+
+## What is .NET Core?
+
+.NET Core is a general purpose development platform maintained by Microsoft and the .NET community on [GitHub](https://github.com/dotnet/core). It is cross-platform, supporting Windows, macOS and Linux, and can be used in device, cloud, and embedded/IoT scenarios.
+
+.NET has several capabilities that make development easier, including automatic memory management, (runtime) generic types, reflection, asynchrony, concurrency, and native interop. Millions of developers take advantage of these capabilities to efficiently build high-quality applications.
+
+You can use C# to write .NET Core apps. C# is simple, powerful, type-safe, and object-oriented while retaining the expressiveness and elegance of C-style languages. Anyone familiar with C and similar languages will find it straightforward to write in C#.
+
+[.NET Core](https://github.com/dotnet/core) is open source (MIT and Apache 2 licenses) and was contributed to the [.NET Foundation](http://dotnetfoundation.org) by Microsoft in 2014. It can be freely adopted by individuals and companies, including for personal, academic or commercial purposes. Multiple companies use .NET Core as part of apps, tools, new platforms and hosting services.
+
+> https://docs.microsoft.com/dotnet/core/
+
+![logo](https://avatars0.githubusercontent.com/u/9141961?v=3&amp;s=100)
+
+## How to use these Images
+
+### Run a sample .NET Core application within a container
+
+The dotnetapp image is a sample application that depends on the [.NET Core Runtime image](https://hub.docker.com/r/microsoft/dotnet). You can run it in a container by running the following command.
+
+```console
+docker run microsoft/dotnet-samples:dotnetapp
+```
+
+Note: The instructions above work for both Linux and Windows containers. The .NET Core docker images use [multi-arch tags](https://github.com/dotnet/announcements/issues/14), which abstract away different operating system choices for most use-cases.
+
+## Image variants
+
+The `microsoft/dotnet-sample` images come in one flavor.
+
+### `microsoft/dotnet-samples:dotnetapp`
+
+This image demonstrates the minimal use of the [.NET Core Runtime image](https://hub.docker.com/r/microsoft/dotnet). It is not intended to be used as the base of another image, but purely used for demonstration purposes.
+
+## Related Repos
+
+See the following related repos for other application types:
+
+- [microsoft/dotnet](https://hub.docker.com/r/microsoft/dotnet/) for .NET Core images.
+- [microsoft/aspnetcore](https://hub.docker.com/r/microsoft/aspnetcore/) for ASP.NET Core images.
+- [microsoft/aspnet](https://hub.docker.com/r/microsoft/aspnet/) for ASP.NET Web Forms and MVC images.
+- [microsoft/dotnet-framework](https://hub.docker.com/r/microsoft/dotnet-framework/) for .NET Framework images (for web applications, see microsoft/aspnet).
+
+## License
+
+View [license information](https://www.microsoft.com/net/dotnet_library_license.htm) for the software contained in this image.
+
+The .NET Core Windows container images use the same license as the [Windows Server 2016 Nano Server base image](https://hub.docker.com/r/microsoft/nanoserver/), as follows:
+
+MICROSOFT SOFTWARE SUPPLEMENTAL LICENSE TERMS
+
+CONTAINER OS IMAGE
+
+Microsoft Corporation (or based on where you live, one of its affiliates) (referenced as “us,” “we,” or “Microsoft”) licenses this Container OS Image supplement to you (“Supplement”). You are licensed to use this Supplement in conjunction with the underlying host operating system software (“Host Software”) solely to assist running the containers feature in the Host Software. The Host Software license terms apply to your use of the Supplement. You may not use it if you do not have a license for the Host Software. You may use this Supplement with each validly licensed copy of the Host Software.
+
+## Supported Docker versions
+
+Supported Docker versions: [the latest release](https://github.com/docker/docker/releases/latest) (down to 1.12.2 on a best-effort basis)
+
+Please see [the Docker installation documentation](https://docs.docker.com/installation/) for details on how to upgrade your Docker daemon.
+
+## User Feedback
+
+### Issues
+
+If you have any problems with or questions about this image, please contact us through a [GitHub issue](https://github.com/dotnet/dotnet-docker-samples/issues).
+
+### Contributing
+
+You are invited to contribute new features, fixes, or updates, large or small; we are always thrilled to receive pull requests, and do our best to process them as fast as we can.
+
+Before you start to code, please read the [.NET Core contribution guidelines](https://github.com/dotnet/coreclr/blob/master/CONTRIBUTING.md).
+
+### Documentation
+
+You can read documentation for .NET Core, including Docker usage in the [.NET Core docs](https://docs.microsoft.com/dotnet/articles/core/). The docs are [open source on GitHub](https://github.com/dotnet/core-docs). Contributions are welcome!

--- a/build-pipeline/README.md
+++ b/build-pipeline/README.md
@@ -1,0 +1,1 @@
+The contents of the [build-pipeline](build-pipeline) folder are used by the .NET Core engineering infrastructure to build and publish the sample Docker images to [microsoft/dotnet-samples](https://hub.docker.com/r/microsoft/dotnet-samples/).

--- a/build-pipeline/dotnet-docker-samples-linux-amd64-images.json
+++ b/build-pipeline/dotnet-docker-samples-linux-amd64-images.json
@@ -1,0 +1,212 @@
+{
+  "build": [
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Cleanup Docker",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "system prune -a -f",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Pull image-builder",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "pull $(image-builder.imageName)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Run image-builder",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo --name $(image-builder.containerName) $(image-builder.imageName) $(image-builder.args)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Cleanup Docker",
+      "timeoutInMinutes": 0,
+      "condition": "always()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "system prune -a -f",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    }
+  ],
+  "options": [
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5bc3cfb7-6b54-4a4b-b5d2-a3905949f8a6"
+      },
+      "inputs": {}
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
+      },
+      "inputs": {
+        "multipliers": "[]",
+        "parallel": "false",
+        "continueOnError": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "a9db38f9-9fdc-478c-b0f9-464221e58316"
+      },
+      "inputs": {
+        "workItemType": "234347",
+        "assignToRequestor": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
+      },
+      "inputs": {}
+    }
+  ],
+  "variables": {
+    "system.debug": {
+      "value": "false",
+      "allowOverride": true
+    },
+    "image-builder.imageName": {
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170824103849"
+    },
+    "image-builder.args": {
+      "value": "build --manifest manifest.json --path $(PB.image-builder.path) --push --username $(PB.docker.username) --password $(PB.docker.password) $(PB.image-builder.customCommonArgs)",
+      "allowOverride": true
+    },
+    "image-builder.containerName": {
+      "value": "$(Build.DefinitionName)-$(Build.BuildId)"
+    },
+    "PB.docker.password": {
+      "value": null,
+      "isSecret": true
+    },
+    "PB.image-builder.customCommonArgs": {
+      "value": ""
+    },
+    "PB.image-builder.path": {
+      "value": ""
+    }
+  },
+  "demands": [
+    "Agent.OS -equals linux"
+  ],
+  "retentionRules": [
+    {
+      "branches": [
+        "+refs/heads/*"
+      ],
+      "artifacts": [],
+      "artifactTypesToDelete": [
+        "FilePath",
+        "SymbolStore"
+      ],
+      "daysToKeep": 10,
+      "minimumToKeep": 1,
+      "deleteBuildRecord": true,
+      "deleteTestResults": true
+    }
+  ],
+  "jobAuthorizationScope": "projectCollection",
+  "jobTimeoutInMinutes": 60,
+  "jobCancelTimeoutInMinutes": 5,
+  "repository": {
+    "properties": {
+      "cleanOptions": "0",
+      "gitLfsSupport": "false",
+      "skipSyncSource": "false",
+      "reportBuildStatus": "true",
+      "fetchDepth": "0",
+      "connectedServiceId": "1e3b2b41-8d83-4240-a16f-6fc0b825d0d6",
+      "apiUrl": "https://api.github.com/repos/dotnet/dotnet-docker-samples",
+      "branchesUrl": "https://api.github.com/repos/dotnet/dotnet-docker-samples/branches",
+      "cloneUrl": "https://github.com/dotnet/dotnet-docker-samples.git",
+      "refsUrl": "https://api.github.com/repos/dotnet/dotnet-docker-samples/git/refs",
+      "checkoutNestedSubmodules": "false"
+    },
+    "id": "https://github.com/dotnet/dotnet-docker-samples.git",
+    "type": "GitHub",
+    "name": "dotnet/dotnet-docker-samples",
+    "url": "https://github.com/dotnet/dotnet-docker-samples.git",
+    "defaultBranch": "master",
+    "clean": "false",
+    "checkoutSubmodules": false
+  },
+  "processParameters": {},
+  "quality": "definition",
+  "queue": {
+    "id": 36,
+    "name": "DotNet-Build",
+    "pool": {
+      "id": 39,
+      "name": "DotNet-Build"
+    }
+  },
+  "id": 6214,
+  "name": "dotnet-docker-samples-linux-amd64-images",
+  "url": "https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_apis/build/Definitions/6214",
+  "path": "\\",
+  "type": "build",
+  "project": {
+    "id": "0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "name": "DevDiv",
+    "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
+    "url": "https://devdiv.visualstudio.com/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "state": "wellFormed",
+    "revision": 418097676
+  }
+}

--- a/build-pipeline/dotnet-docker-samples-linux-arm32v7-images.json
+++ b/build-pipeline/dotnet-docker-samples-linux-arm32v7-images.json
@@ -194,7 +194,8 @@
     }
   },
   "demands": [
-    "Agent.Name -equals DDVSOWIN10AGE01"
+    "VSTS_OS -equals Windows_10_Enterprise",
+    "DockerVersion"
   ],
   "retentionRules": [
     {
@@ -240,11 +241,11 @@
   "processParameters": {},
   "quality": "definition",
   "queue": {
-    "id": 159,
-    "name": "DotNetCore-Test",
+    "id": 832,
+    "name": "DotNetCore-Infra",
     "pool": {
-      "id": 83,
-      "name": "DotNetCore-Test"
+      "id": 135,
+      "name": "DotNetCore-Infra"
     }
   },
   "id": 6214,

--- a/build-pipeline/dotnet-docker-samples-linux-arm32v7-images.json
+++ b/build-pipeline/dotnet-docker-samples-linux-arm32v7-images.json
@@ -1,0 +1,263 @@
+{
+  "build": [
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Cleanup Docker",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "system prune -a -f",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "environment": {},
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Clone Repo",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "refName": "Task3",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run $(docker.commonRunArgs) $(docker.gitEnabledImageName) git clone https://github.com/dotnet/dotnet-docker-samples.git /repo",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "environment": {},
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Checkout Source",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "refName": "Task3",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run $(docker.commonRunArgs) $(docker.gitEnabledImageName) git checkout $(Build.SourceVersion)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Pull image-builder",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "pull $(image-builder.imageName)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Run image-builder",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run  $(docker.commonRunArgs) -v /var/run/docker.sock:/var/run/docker.sock $(image-builder.imageName) $(image-builder.args)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Cleanup Docker",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "system prune -a -f",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    }
+  ],
+  "options": [
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5bc3cfb7-6b54-4a4b-b5d2-a3905949f8a6"
+      },
+      "inputs": {}
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
+      },
+      "inputs": {
+        "multipliers": "[]",
+        "parallel": "false",
+        "continueOnError": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "a9db38f9-9fdc-478c-b0f9-464221e58316"
+      },
+      "inputs": {
+        "workItemType": "234347",
+        "assignToRequestor": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
+      },
+      "inputs": {}
+    }
+  ],
+  "variables": {
+    "system.debug": {
+      "value": "false",
+      "allowOverride": true
+    },
+    "docker.commonRunArgs": {
+      "value": "--rm -v $(docker.volumeName):/repo -w /repo --name $(docker.containerName)"
+    },
+    "docker.containerName": {
+      "value": "$(Build.DefinitionName)-$(Build.BuildId)"
+    },
+    "docker.gitEnabledImageName": {
+      "value": "buildpack-deps:stretch-scm"
+    },
+    "docker.volumeName": {
+      "value": "$(Build.DefinitionName)-$(Build.BuildId)"
+    },
+    "image-builder.imageName": {
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170824103849"
+    },
+    "image-builder.args": {
+      "value": "build --manifest manifest.json --path $(PB.image-builder.path) --architecture arm --push --username $(PB.docker.username) --password $(PB.docker.password) $(PB.image-builder.customCommonArgs)",
+      "allowOverride": true
+    },
+    "PB.docker.password": {
+      "value": null,
+      "isSecret": true
+    },
+    "PB.image-builder.customCommonArgs": {
+      "value": ""
+    },
+    "PB.image-builder.path": {
+      "value": ""
+    }
+  },
+  "demands": [
+    "Agent.Name -equals DDVSOWIN10AGE01"
+  ],
+  "retentionRules": [
+    {
+      "branches": [
+        "+refs/heads/*"
+      ],
+      "artifacts": [],
+      "artifactTypesToDelete": [
+        "FilePath",
+        "SymbolStore"
+      ],
+      "daysToKeep": 10,
+      "minimumToKeep": 1,
+      "deleteBuildRecord": true,
+      "deleteTestResults": true
+    }
+  ],
+  "jobAuthorizationScope": "projectCollection",
+  "jobTimeoutInMinutes": 60,
+  "jobCancelTimeoutInMinutes": 5,
+  "repository": {
+    "properties": {
+      "cleanOptions": "0",
+      "gitLfsSupport": "false",
+      "skipSyncSource": "false",
+      "reportBuildStatus": "true",
+      "fetchDepth": "0",
+      "connectedServiceId": "1e3b2b41-8d83-4240-a16f-6fc0b825d0d6",
+      "apiUrl": "https://api.github.com/repos/dotnet/dotnet-docker-samples",
+      "branchesUrl": "https://api.github.com/repos/dotnet/dotnet-docker-samples/branches",
+      "cloneUrl": "https://github.com/dotnet/dotnet-docker-samples.git",
+      "refsUrl": "https://api.github.com/repos/dotnet/dotnet-docker-samples/git/refs",
+      "checkoutNestedSubmodules": "false"
+    },
+    "id": "https://github.com/dotnet/dotnet-docker-samples.git",
+    "type": "GitHub",
+    "name": "dotnet/dotnet-docker-samples",
+    "url": "https://github.com/dotnet/dotnet-docker-samples.git",
+    "defaultBranch": "master",
+    "clean": "false",
+    "checkoutSubmodules": false
+  },
+  "processParameters": {},
+  "quality": "definition",
+  "queue": {
+    "id": 159,
+    "name": "DotNetCore-Test",
+    "pool": {
+      "id": 83,
+      "name": "DotNetCore-Test"
+    }
+  },
+  "id": 6214,
+  "name": "dotnet-docker-samples-linux-arm32v7-images",
+  "url": "https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_apis/build/Definitions/6214",
+  "path": "\\",
+  "type": "build",
+  "project": {
+    "id": "0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "name": "DevDiv",
+    "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
+    "url": "https://devdiv.visualstudio.com/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "state": "wellFormed",
+    "revision": 418097676
+  }
+}

--- a/build-pipeline/dotnet-docker-samples-post-image-build.json
+++ b/build-pipeline/dotnet-docker-samples-post-image-build.json
@@ -1,0 +1,236 @@
+{
+  "build": [
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Cleanup Docker",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "system prune -a -f",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Pull image-builder",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "pull $(image-builder.imageName)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Publish Manifest",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo --name $(image-builder.containerName) $(image-builder.imageName) $(image-builder.publishManifest.args)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Update Readme",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo --name $(image-builder.containerName) $(image-builder.imageName) $(image-builder.updateReadme.args)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Cleanup Docker",
+      "timeoutInMinutes": 0,
+      "condition": "always()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "system prune -a -f",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    }
+  ],
+  "options": [
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5bc3cfb7-6b54-4a4b-b5d2-a3905949f8a6"
+      },
+      "inputs": {}
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
+      },
+      "inputs": {
+        "multipliers": "[]",
+        "parallel": "false",
+        "continueOnError": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "a9db38f9-9fdc-478c-b0f9-464221e58316"
+      },
+      "inputs": {
+        "workItemType": "234347",
+        "assignToRequestor": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
+      },
+      "inputs": {}
+    }
+  ],
+  "variables": {
+    "system.debug": {
+      "value": "false",
+      "allowOverride": true
+    },
+    "image-builder.imageName": {
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170824103849"
+    },
+    "image-builder.common.args": {
+      "value": "--manifest manifest.json --username $(PB.docker.username) --password $(PB.docker.password) $(PB.image-builder.customCommonArgs)",
+      "allowOverride": true
+    },
+    "image-builder.publishManifest.args": {
+      "value": "publishManifest $(image-builder.common.args)",
+      "allowOverride": true
+    },
+    "image-builder.updateReadme.args": {
+      "value": "updateReadme $(image-builder.common.args)",
+      "allowOverride": true
+    },
+    "image-builder.containerName": {
+      "value": "$(Build.DefinitionName)-$(Build.BuildId)"
+    },
+    "PB.image-builder.customCommonArgs": {
+      "value": ""
+    },
+    "PB.docker.password": {
+      "value": null,
+      "isSecret": true
+    }
+  },
+  "demands": [
+    "Agent.OS -equals linux"
+  ],
+  "retentionRules": [
+    {
+      "branches": [
+        "+refs/heads/*"
+      ],
+      "artifacts": [],
+      "artifactTypesToDelete": [
+        "FilePath",
+        "SymbolStore"
+      ],
+      "daysToKeep": 10,
+      "minimumToKeep": 1,
+      "deleteBuildRecord": true,
+      "deleteTestResults": true
+    }
+  ],
+  "jobAuthorizationScope": "projectCollection",
+  "jobTimeoutInMinutes": 60,
+  "jobCancelTimeoutInMinutes": 5,
+  "repository": {
+    "properties": {
+      "cleanOptions": "0",
+      "gitLfsSupport": "false",
+      "skipSyncSource": "false",
+      "reportBuildStatus": "true",
+      "fetchDepth": "0",
+      "connectedServiceId": "1e3b2b41-8d83-4240-a16f-6fc0b825d0d6",
+      "apiUrl": "https://api.github.com/repos/dotnet/dotnet-docker-samples",
+      "branchesUrl": "https://api.github.com/repos/dotnet/dotnet-docker-samples/branches",
+      "cloneUrl": "https://github.com/dotnet/dotnet-docker-samples.git",
+      "refsUrl": "https://api.github.com/repos/dotnet/dotnet-docker-samples/git/refs",
+      "checkoutNestedSubmodules": "false"
+    },
+    "id": "https://github.com/dotnet/dotnet-docker-samples.git",
+    "type": "GitHub",
+    "name": "dotnet/dotnet-docker-samples",
+    "url": "https://github.com/dotnet/dotnet-docker-samples.git",
+    "defaultBranch": "master",
+    "clean": "false",
+    "checkoutSubmodules": false
+  },
+  "processParameters": {},
+  "quality": "definition",
+  "queue": {
+    "id": 36,
+    "name": "DotNet-Build",
+    "pool": {
+      "id": 39,
+      "name": "DotNet-Build"
+    }
+  },
+  "id": 6218,
+  "name": "dotnet-docker-samples-post-image-build",
+  "url": "https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_apis/build/Definitions/6218",
+  "path": "\\",
+  "type": "build",
+  "project": {
+    "id": "0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "name": "DevDiv",
+    "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
+    "url": "https://devdiv.visualstudio.com/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "state": "wellFormed",
+    "revision": 418097676
+  }
+}

--- a/build-pipeline/dotnet-docker-samples-windows-amd64-images.json
+++ b/build-pipeline/dotnet-docker-samples-windows-amd64-images.json
@@ -1,0 +1,273 @@
+{
+  "build": [
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Cleanup Docker",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "",
+        "workingFolder": "",
+        "inlineScript": "docker ps -a -q | %{docker rm -f $_}\n\ndocker images | where {-Not ($_.StartsWith(\"microsoft/nanoserver \") -Or $_.StartsWith(\"REPOSITORY \"))} | %{$_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2]} | select-object -unique | %{docker rmi -f $_}",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Pull image-builder",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "pull $(image-builder.imageName)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Create container",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "create --name $(image-builder.containerName) $(image-builder.imageName)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Copy image-builder locally",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker ",
+        "arguments": "cp $(image-builder.containerName):/image-builder $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Cleanup container",
+      "timeoutInMinutes": 0,
+      "condition": "always()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "rmi -f $(image-builder.imageName)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Run image-builder",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe",
+        "arguments": "$(image-builder.args)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Cleanup Docker",
+      "timeoutInMinutes": 0,
+      "condition": "always()",
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "",
+        "workingFolder": "",
+        "inlineScript": "docker ps -a -q | %{docker rm -f $_}\n\ndocker images | where {-Not ($_.StartsWith(\"microsoft/nanoserver \") -Or $_.StartsWith(\"REPOSITORY \"))} | %{$_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2]} | select-object -unique | %{docker rmi -f $_}",
+        "failOnStandardError": "true"
+      }
+    }
+  ],
+  "options": [
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5bc3cfb7-6b54-4a4b-b5d2-a3905949f8a6"
+      },
+      "inputs": {}
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
+      },
+      "inputs": {
+        "multipliers": "[]",
+        "parallel": "false",
+        "continueOnError": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "a9db38f9-9fdc-478c-b0f9-464221e58316"
+      },
+      "inputs": {
+        "workItemType": "234347",
+        "assignToRequestor": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
+      },
+      "inputs": {}
+    }
+  ],
+  "variables": {
+    "system.debug": {
+      "value": "false",
+      "allowOverride": true
+    },
+    "image-builder.imageName": {
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20170824103908"
+    },
+    "image-builder.args": {
+      "value": "build --manifest manifest.json --path $(PB.image-builder.path) --push --username $(PB.docker.username) --password $(PB.docker.password) $(PB.image-builder.customCommonArgs)",
+      "allowOverride": true
+    },
+    "image-builder.containerName": {
+      "value": "$(Build.DefinitionName)-$(Build.BuildId)"
+    },
+    "PB.docker.password": {
+      "value": null,
+      "isSecret": true
+    },
+    "PB.image-builder.customCommonArgs": {
+      "value": ""
+    },
+    "PB.image-builder.path": {
+      "value": ""
+    }
+  },
+  "demands": [
+    "Agent.OS -equals Windows_NT"
+  ],
+  "retentionRules": [
+    {
+      "branches": [
+        "+refs/heads/*"
+      ],
+      "artifacts": [],
+      "artifactTypesToDelete": [
+        "FilePath",
+        "SymbolStore"
+      ],
+      "daysToKeep": 10,
+      "minimumToKeep": 1,
+      "deleteBuildRecord": true,
+      "deleteTestResults": true
+    }
+  ],
+  "jobAuthorizationScope": "projectCollection",
+  "jobTimeoutInMinutes": 60,
+  "jobCancelTimeoutInMinutes": 5,
+  "repository": {
+    "properties": {
+      "cleanOptions": "1",
+      "gitLfsSupport": "false",
+      "skipSyncSource": "false",
+      "reportBuildStatus": "true",
+      "fetchDepth": "0",
+      "connectedServiceId": "1e3b2b41-8d83-4240-a16f-6fc0b825d0d6",
+      "apiUrl": "https://api.github.com/repos/dotnet/dotnet-docker-samples",
+      "branchesUrl": "https://api.github.com/repos/dotnet/dotnet-docker-samples/branches",
+      "cloneUrl": "https://github.com/dotnet/dotnet-docker-samples.git",
+      "refsUrl": "https://api.github.com/repos/dotnet/dotnet-docker-samples/git/refs",
+      "checkoutNestedSubmodules": "false"
+    },
+    "id": "https://github.com/dotnet/dotnet-docker-samples.git",
+    "type": "GitHub",
+    "name": "dotnet/dotnet-docker-samples",
+    "url": "https://github.com/dotnet/dotnet-docker-samples.git",
+    "defaultBranch": "master",
+    "clean": "true",
+    "checkoutSubmodules": false
+  },
+  "processParameters": {},
+  "quality": "definition",
+  "queue": {
+    "id": 330,
+    "name": "DotNetCore-Build",
+    "pool": {
+      "id": 97,
+      "name": "DotNetCore-Build"
+    }
+  },
+  "id": 6216,
+  "name": "dotnet-docker-samples-windows-amd64-images",
+  "url": "https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_apis/build/Definitions/6216",
+  "path": "\\",
+  "type": "build",
+  "project": {
+    "id": "0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "name": "DevDiv",
+    "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
+    "url": "https://devdiv.visualstudio.com/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "state": "wellFormed",
+    "revision": 418097676
+  }
+}

--- a/build-pipeline/pipeline.json
+++ b/build-pipeline/pipeline.json
@@ -1,0 +1,60 @@
+{
+  "Repository": "dotnet-docker-samples",
+  "Definitions": {
+    "Path": ".",
+    "Type": "VSTS",
+    "BaseUrl": "https://devdiv.visualstudio.com/DefaultCollection",
+    "SkipBranchAndVersionOverrides": "false"
+  },
+  "Pipelines": [
+    {
+      "Name": "Build Linux AMD64 Images",
+      "Parameters": {
+        "TreatWarningsAsErrors": "false"
+      },
+      "Definitions": [
+        {
+          "Name": "dotnet-docker-samples-linux-amd64-images"
+        }
+      ]
+    },
+    {
+      "Name": "Build Linux ARM32v7 Images",
+      "Parameters": {
+        "TreatWarningsAsErrors": "false"
+      },
+      "Definitions": [
+        {
+          "Name": "dotnet-docker-samples-linux-arm32v7-images"
+        }
+      ]
+    },
+    {
+      "Name": "Build Windows AMD64 Images",
+      "Parameters": {
+        "TreatWarningsAsErrors": "false"
+      },
+      "Definitions": [
+        {
+          "Name": "dotnet-docker-samples-windows-amd64-images"
+        }
+      ]
+    },
+    {
+      "Name": "Post Image Build",
+      "Parameters": {
+        "TreatWarningsAsErrors": "false"
+      },
+      "Definitions": [
+        {
+          "Name": "dotnet-docker-samples-post-image-build"
+        }
+      ],
+      "DependsOn": [
+        "Build Windows AMD64 Images",
+        "Build Linux AMD64 Images",
+        "Build Linux ARM32v7 Images"
+      ]
+    }
+  ]
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,40 @@
+{
+  "repos": [
+    {
+      "name": "microsoft/dotnet-samples",
+      "readmePath": "README.DockerHub.md",
+      "images": [
+        {
+          "sharedTags": {
+            "dotnetapp": {},
+            "latest": {}
+          },
+          "platforms": [
+            {
+              "dockerfile": "dotnetapp-prod/Dockerfile",
+              "os": "windows",
+              "tags": {
+                "dotnetapp-nanoserver": {}
+              }
+            },
+            {
+              "dockerfile": "dotnetapp-prod/Dockerfile",
+              "os": "linux",
+              "tags": {
+                "dotnetapp-stretch": {}
+              }
+            },
+            {
+              "architecture": "arm",
+              "dockerfile": "dotnetapp-prod/Dockerfile.arm32",
+              "os": "linux",
+              "tags": {
+                "dotnetapp-stretch-arm32v7": {}
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
With the use of the image-builder tool to build and push the images to Docker Hub in conjunction with using multi-stage builds,  there is no longer a need for the DockerHub branch.  I am therefore proposing we use the dotnetapp-prod sample in the master branch as the sample we build and push to Docker Hub.  