### PR TITLE
Suffix sac2016 to Nano Server Dockerfile

### DIFF
--- a/README.DockerHub.md
+++ b/README.DockerHub.md
@@ -4,7 +4,7 @@
 
 # Supported Windows Server 2016 Version 1709 (Fall Creators Update) amd64 tags
 
-- [`dotnetapp-nanoserver-1709`, `dotnetapp`, `latest` (*dotnetapp-prod/Dockerfile*)](https://github.com/dotnet/dotnet-docker-samples/blob/master/dotnetapp-prod/Dockerfile)
+- [`dotnetapp-nanoserver-1709` (*dotnetapp-prod/Dockerfile*)](https://github.com/dotnet/dotnet-docker-samples/blob/master/dotnetapp-prod/Dockerfile)
 
 # Supported Windows Server 2016 amd64 tags
 

--- a/README.DockerHub.md
+++ b/README.DockerHub.md
@@ -4,11 +4,11 @@
 
 # Supported Windows Server 2016 Version 1709 (Fall Creators Update) amd64 tags
 
-- [`dotnetapp-nanoserver-1709` (*dotnetapp-prod/Dockerfile*)](https://github.com/dotnet/dotnet-docker-samples/blob/master/dotnetapp-prod/Dockerfile)
+- [`dotnetapp-nanoserver-1709`, `dotnetapp`, `latest` (*dotnetapp-prod/Dockerfile*)](https://github.com/dotnet/dotnet-docker-samples/blob/master/dotnetapp-prod/Dockerfile)
 
 # Supported Windows Server 2016 amd64 tags
 
-- [`dotnetapp-nanoserver`, `dotnetapp`, `latest` (*dotnetapp-prod/Dockerfile*)](https://github.com/dotnet/dotnet-docker-samples/blob/master/dotnetapp-prod/Dockerfile)
+- [`dotnetapp-nanoserver-sac2016`, `dotnetapp`, `latest` (*dotnetapp-prod/Dockerfile*)](https://github.com/dotnet/dotnet-docker-samples/blob/master/dotnetapp-prod/Dockerfile)
 
 # Supported Linux arm32 tags
 

--- a/dotnetapp-selfcontained/Dockerfile.nano
+++ b/dotnetapp-selfcontained/Dockerfile.nano
@@ -11,7 +11,7 @@ COPY . ./
 RUN dotnet publish -c Release -r win-x64 -o out
 
 # build runtime image
-FROM microsoft/nanoserver:10.0.14393.1770
+FROM microsoft/nanoserver:sac2016
 WORKDIR /app
 COPY --from=build-env /app/out ./
 ENTRYPOINT ["dotnetapp.exe"]

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,7 @@
               "os": "windows",
               "osVersion": "10.0.14393",
               "tags": {
-                "dotnetapp-nanoserver": {}
+                "dotnetapp-nanoserver-sac2016": {}
               }
             },
             {


### PR DESCRIPTION
Add `sac2016` suffix to Dockerfile tag  corresponding to Nano Server Semi Annual Channel sample.